### PR TITLE
fix: cash 생성 시 readonly로 되어있어서 생성 안되는 문제 해결

### DIFF
--- a/src/main/java/com/mfc/payment/application/CashServiceImpl.java
+++ b/src/main/java/com/mfc/payment/application/CashServiceImpl.java
@@ -46,7 +46,7 @@ public class CashServiceImpl implements CashService {
 	}
 
 	@Override
-	@Transactional(readOnly = true)
+	@Transactional
 	public CashResponse getCashBalance(String uuid) {
 		Cash cash = getCashByUuid(uuid);
 		return CashResponse.builder().balance(cash.getBalance()).build();


### PR DESCRIPTION
## 📣cash 생성 시 readonly로 되어있어서 생성 안되는 문제 해결
### 📅 2024.06.30

### 🌵Branch
feature/settlement-cancel-amount

### 📢 Description
cash 생성 시 readonly로 되어있어서 생성 안되는 문제 해결

### 🛠️Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
(참고사항을 적어주세요)